### PR TITLE
defines a single docker image with api server and localstack db

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM localstack/localstack:stable
+
+# make sure the directory that `apt` will install to has precedence in the PATH
+ENV PATH="/usr/bin:${PATH}"
+# setup and install node 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+RUN apt update && apt install -y nodejs
+
+# install npm dependencies and build the api server code
+COPY . .
+RUN npm ci
+RUN npm run build
+
+# pre-configure `localstack` to include dynamo with populated tables
+ENV SERVICES=dynamodb
+ENV AWS_ACCESS_KEY_ID=dummy
+ENV AWS_SECRET_ACCESS_KEY=dummy
+COPY init_dynamodb.sh /etc/localstack/init/ready.d/init-aws.sh
+
+ENTRYPOINT [ "bash", "-c", "npm run start:local & docker-entrypoint.sh" ]


### PR DESCRIPTION
this image can be used in the local development workflow for the frontend, which would mean no need to also pull and start the backend repo.

areas for future improvement:
1. the `localstack/localstack` base image runs everything as `root`, which we should change to a user with less privileges
2. we could probably make the image smaller by doing a multi-stage build, so we don't include the `src` directory and npm dev dependencies in the final image.
